### PR TITLE
fix(statistics): change format month/yy and configure rate-limit

### DIFF
--- a/Backend/src/ShoeStore.Api/Program.cs
+++ b/Backend/src/ShoeStore.Api/Program.cs
@@ -117,7 +117,7 @@ builder.Services.AddRateLimiter(options =>
                 userId,
                 _ => new TokenBucketRateLimiterOptions
                 {
-                    TokenLimit = 10,
+                    TokenLimit = 15,
                     TokensPerPeriod = 3,
                     ReplenishmentPeriod = TimeSpan.FromMinutes(1)
                 });
@@ -126,7 +126,7 @@ builder.Services.AddRateLimiter(options =>
             httpContext.Connection.RemoteIpAddress?.ToString() ?? "anonymous",
             _ => new FixedWindowRateLimiterOptions
             {
-                PermitLimit = 10,
+                PermitLimit = 15,
                 Window = TimeSpan.FromMinutes(1),
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 0

--- a/Backend/src/ShoeStore.Application/Services/StatisticsService.cs
+++ b/Backend/src/ShoeStore.Application/Services/StatisticsService.cs
@@ -171,7 +171,7 @@ public class StatisticsService(IInvoiceRepository invoiceRepository) : IStatisti
             for (var m = startMonth; m <= endMonth; m = m.AddMonths(1))
             {
                 var match = rawData.FirstOrDefault(data => data.Date.Month == m.Month && data.Date.Year == m.Year);
-                result.Add(new ChartDataDto(m.ToString("MM/yyyy"), match.Revenue));
+                result.Add(new ChartDataDto(m.ToString("MM/yy"), match.Revenue));
             }
         }
         else // groupByType == "day"

--- a/Backend/test/ShoeStore.Tests/ShoeStore.Tests.csproj
+++ b/Backend/test/ShoeStore.Tests/ShoeStore.Tests.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="MockQueryable.Moq" Version="10.0.5"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased API request capacity limits from 10 to 15 requests per period for all users (authenticated and unauthenticated), enhancing overall throughput and reducing rate-limiting constraints
  * Updated monthly revenue chart date format from MM/yyyy to MM/yy notation for more compact visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->