### PR TITLE
feat: redesign user order management UI

### DIFF
--- a/Frontend/app/src/main/java/com/example/shoestoreapp/MainActivity.kt
+++ b/Frontend/app/src/main/java/com/example/shoestoreapp/MainActivity.kt
@@ -414,6 +414,9 @@ private fun NavGraphBuilder.userGraph(
                     )
                 )
             },
+            onMyOrdersClick = {
+                navController.navigate(Routes.userInvoiceList())
+            },
             onLogoutClick = {
                 scope.launch {
                     tokenManager.clearAuthInfo()
@@ -802,7 +805,9 @@ private fun handleUserInvoiceTabSelection(tab: BottomNavTab, navController: NavH
             )
         }
 
-        BottomNavTab.BAG -> Unit
+        BottomNavTab.BAG -> {
+            navController.navigateAndPopTo(Routes.CART, Routes.USER_INVOICE_LIST_BASE)
+        }
         BottomNavTab.AI -> {
             navController.navigateAndPopTo(Routes.userAiAssistant(), Routes.USER_INVOICE_LIST_BASE)
         }

--- a/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/ui/UserInvoiceScreen.kt
+++ b/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/ui/UserInvoiceScreen.kt
@@ -5,16 +5,28 @@ import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -36,11 +48,6 @@ import androidx.compose.ui.unit.sp
 import com.example.shoestoreapp.core.utils.TokenManager
 import com.example.shoestoreapp.features.invoice.model.Invoice
 import com.example.shoestoreapp.features.invoice.model.InvoiceStatus
-import com.example.shoestoreapp.features.invoice.ui.components.InvoiceStatusFilterChipColors
-import com.example.shoestoreapp.features.invoice.ui.components.InvoiceStatusFilterChipDimensions
-import com.example.shoestoreapp.features.invoice.ui.components.InvoiceStatusFilterChipStyle
-import com.example.shoestoreapp.features.invoice.ui.components.InvoiceStatusFilterChipTypography
-import com.example.shoestoreapp.features.invoice.ui.components.InvoiceStatusFilterChips
 import com.example.shoestoreapp.features.user.invoice.data.OrderStatusSignalRManager
 import com.example.shoestoreapp.features.user.invoice.ui.components.UserInvoiceDetailsBottomSheet
 import com.example.shoestoreapp.features.user.invoice.ui.components.UserOrderCard
@@ -112,7 +119,7 @@ fun UserInvoiceScreen(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         bottomBar = {
             BottomNavBar(
-                selectedTab = BottomNavTab.BAG,
+                selectedTab = BottomNavTab.PROFILE,
                 onTabSelected = onTabSelected
             )
         }
@@ -120,17 +127,12 @@ fun UserInvoiceScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color.White)
+                .background(Color(0xFFF7F7F8))
                 .padding(paddingValues)
-                .padding(horizontal = 16.dp, vertical = 16.dp),
+                .padding(horizontal = 14.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text(
-                text = "My Orders",
-                color = Color.Black,
-                fontSize = 24.sp,
-                fontWeight = FontWeight.ExtraBold
-            )
+            OrdersHeader()
 
             UserInvoiceFilterRow(
                 selectedStatus = state.selectedStatus,
@@ -177,7 +179,7 @@ fun UserInvoiceScreen(
                     // Main list with per-item actions.
                     LazyColumn(
                         modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         items(
                             items = viewModel.filteredInvoices,
@@ -185,6 +187,7 @@ fun UserInvoiceScreen(
                         ) { invoice ->
                             UserOrderCard(
                                 invoice = invoice,
+                                previewDetail = state.orderPreviewDetails[invoice.publicId],
                                 isCancelling = state.isCancelling && state.cancellingInvoicePublicId == invoice.publicId,
                                 onCancelClick = {
                                     // Show confirm before firing cancel API.
@@ -235,27 +238,79 @@ fun UserInvoiceScreen(
 }
 
 @Composable
+private fun OrdersHeader() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+    ) {
+        IconButton(onClick = {}) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = "Search orders",
+                tint = Color.Black
+            )
+        }
+
+        Text(
+            text = "Orders",
+            color = Color.Black,
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Black
+        )
+
+        IconButton(onClick = {}) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = "More order options",
+                tint = Color.Black
+            )
+        }
+    }
+}
+
+@Composable
 private fun UserInvoiceFilterRow(
     selectedStatus: InvoiceStatus?,
     onFilterSelected: (InvoiceStatus?) -> Unit
 ) {
-    InvoiceStatusFilterChips(
-        selectedStatus = selectedStatus,
-        onFilterSelected = onFilterSelected,
+    val filters = listOf(
+        OrderFilter(null, "All"),
+        OrderFilter(InvoiceStatus.PENDING, "To confirm"),
+        OrderFilter(InvoiceStatus.PAID, "To ship"),
+        OrderFilter(InvoiceStatus.DELIVERING, "Shipping"),
+        OrderFilter(InvoiceStatus.DELIVERED, "Completed"),
+        OrderFilter(InvoiceStatus.CANCELLED, "Cancelled")
+    )
+
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(bottom = 2.dp),
-        style = InvoiceStatusFilterChipStyle(
-            dimensions = InvoiceStatusFilterChipDimensions(
-                chipCornerRadius = 18.dp,
-                chipHorizontalPadding = 12.dp,
-                chipVerticalPadding = 7.dp
-            ),
-            colors = InvoiceStatusFilterChipColors(
-                unselectedTextColor = Color(0xFF888888)
-            ),
-            typography = InvoiceStatusFilterChipTypography(letterSpacing = 0.sp),
-            showSelectedBorder = true
-        )
-    )
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        filters.forEach { filter ->
+            val isSelected = selectedStatus == filter.status
+            Text(
+                text = filter.label,
+                modifier = Modifier
+                    .background(
+                        color = if (isSelected) Color.Black else Color(0xFFF0F0F1),
+                        shape = RoundedCornerShape(999.dp)
+                    )
+                    .clickable { onFilterSelected(filter.status) }
+                    .padding(horizontal = 22.dp, vertical = 12.dp),
+                color = if (isSelected) Color.White else Color(0xFF5D6570),
+                fontSize = 15.sp,
+                fontWeight = FontWeight.ExtraBold,
+                maxLines = 1
+            )
+            Spacer(modifier = Modifier.width(0.dp))
+        }
+    }
 }
+
+private data class OrderFilter(
+    val status: InvoiceStatus?,
+    val label: String
+)

--- a/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/ui/components/UserInvoiceDetailsBottomSheet.kt
+++ b/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/ui/components/UserInvoiceDetailsBottomSheet.kt
@@ -1,9 +1,11 @@
 package com.example.shoestoreapp.features.user.invoice.ui.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -16,18 +18,23 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -43,81 +50,174 @@ fun UserInvoiceDetailsBottomSheet(
     onDismissRequest: () -> Unit
 ) {
     val selectedInvoice = state.selectedInvoice ?: return
+    val subtotal = state.invoiceDetails.sumOf { detail ->
+        detail.unitPrice.toLong() * detail.quantity.toLong()
+    }
+    val totalText = formatAdminPrice(selectedInvoice.finalPrice.orEmpty())
 
     ModalBottomSheet(onDismissRequest = onDismissRequest) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(0.75f)
-                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .fillMaxHeight(0.88f)
+                .padding(horizontal = 24.dp, vertical = 8.dp)
         ) {
             if (state.isDetailLoading) {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             } else {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    Text(
-                        text = "Order details",
-                        fontSize = 28.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = Color.Black
-                    )
-                    Spacer(modifier = Modifier.height(12.dp))
-
-                    UserDetailMetaRow(
-                        label = "Phone",
-                        value = selectedInvoice.phones.orEmpty().ifBlank { "-" }
-                    )
-                    Spacer(modifier = Modifier.height(6.dp))
-                    UserDetailMetaRow(
-                        label = "Address",
-                        value = selectedInvoice.address.orEmpty().ifBlank { "-" }
-                    )
-                    Spacer(modifier = Modifier.height(6.dp))
-                    UserDetailMetaRow(
-                        label = "Created",
-                        value = formatAdminDate(selectedInvoice.createdAt.orEmpty().ifBlank { "-" })
-                    )
-                    Spacer(modifier = Modifier.height(14.dp))
-
-                    Row(modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)) {
-                        Text(
-                            text = "Product",
-                            modifier = Modifier.weight(2f),
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 16.sp
-                        )
-                        Text(
-                            text = "Qty",
-                            modifier = Modifier.weight(1.5f),
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 16.sp,
-                            textAlign = TextAlign.Center
-                        )
-                        Text(
-                            text = "Unit price",
-                            modifier = Modifier.weight(1.5f),
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 16.sp,
-                            textAlign = TextAlign.End
-                        )
-                    }
-                    HorizontalDivider(color = Color.LightGray)
-
-                    if (state.invoiceDetails.isEmpty()) {
-                        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(18.dp)
+                    ) {
+                        item {
                             Text(
-                                text = "No details found for this order.",
-                                color = Color(0xFF6D6D6D),
-                                fontSize = 16.sp,
-                                modifier = Modifier.align(Alignment.Center)
+                                text = "Order details",
+                                fontSize = 30.sp,
+                                fontWeight = FontWeight.Black,
+                                color = Color.Black
                             )
                         }
-                    } else {
-                        LazyColumn(modifier = Modifier.weight(1f)) {
+
+                        item {
+                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                UserDetailMetaRow(
+                                    label = "Phone",
+                                    value = selectedInvoice.phones.orEmpty().ifBlank { "-" }
+                                )
+                                UserDetailMetaRow(
+                                    label = "Address",
+                                    value = selectedInvoice.address.orEmpty().ifBlank { "-" }
+                                )
+                                UserDetailMetaRow(
+                                    label = "Created",
+                                    value = formatAdminDate(selectedInvoice.createdAt.orEmpty().ifBlank { "-" })
+                                )
+                            }
+                        }
+
+                        item {
+                            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                                Row(modifier = Modifier.fillMaxWidth()) {
+                                    Text(
+                                        text = "Product",
+                                        modifier = Modifier.weight(2.2f),
+                                        fontWeight = FontWeight.Black,
+                                        fontSize = 16.sp
+                                    )
+                                    Text(
+                                        text = "Qty",
+                                        modifier = Modifier.weight(0.7f),
+                                        fontWeight = FontWeight.Black,
+                                        fontSize = 16.sp,
+                                        textAlign = TextAlign.Center
+                                    )
+                                    Text(
+                                        text = "Unit price",
+                                        modifier = Modifier.weight(1.3f),
+                                        fontWeight = FontWeight.Black,
+                                        fontSize = 16.sp,
+                                        textAlign = TextAlign.End
+                                    )
+                                }
+                                HorizontalDivider(color = Color(0xFFD8CED1))
+                            }
+                        }
+
+                        if (state.invoiceDetails.isEmpty()) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(120.dp)
+                                ) {
+                                    Text(
+                                        text = "No details found for this order.",
+                                        color = Color(0xFF6D6D6D),
+                                        fontSize = 16.sp,
+                                        modifier = Modifier.align(Alignment.Center)
+                                    )
+                                }
+                            }
+                        } else {
                             items(state.invoiceDetails) { detail ->
                                 UserInvoiceDetailRow(detail = detail)
-                                HorizontalDivider(color = Color(0xFFF0F0F0))
                             }
+                        }
+
+                        item {
+                            Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                                HorizontalDivider(color = Color(0xFFD8CED1))
+                                PriceSummaryRow(
+                                    label = "Subtotal",
+                                    value = formatAdminPrice(subtotal.toString())
+                                )
+                                PriceSummaryRow(
+                                    label = "Payment method",
+                                    value = selectedInvoice.paymentMethod.orEmpty().ifBlank { "-" }
+                                )
+                                HorizontalDivider(color = Color(0xFFD8CED1))
+                                PriceSummaryRow(
+                                    label = "Total",
+                                    value = totalText,
+                                    labelWeight = FontWeight.Black,
+                                    valueWeight = FontWeight.Black,
+                                    valueSize = 25.sp
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                            }
+                        }
+                    }
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 12.dp, bottom = 10.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        OutlinedButton(
+                            onClick = {},
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(54.dp),
+                            shape = RoundedCornerShape(12.dp),
+                            border = BorderStroke(1.dp, Color(0xFF6F676B)),
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                containerColor = Color.White,
+                                contentColor = Color.Black
+                            )
+                        ) {
+                            Text(
+                                text = "Contact support",
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                maxLines = 1
+                            )
+                        }
+
+                        Button(
+                            onClick = {},
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(54.dp),
+                            shape = RoundedCornerShape(12.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Color.Black,
+                                contentColor = Color.White
+                            ),
+                            contentPadding = PaddingValues(horizontal = 8.dp)
+                        ) {
+                            Text(
+                                text = "Track order",
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                maxLines = 1
+                            )
                         }
                     }
                 }
@@ -129,56 +229,77 @@ fun UserInvoiceDetailsBottomSheet(
 @Composable
 private fun UserInvoiceDetailRow(detail: Detail) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 12.dp),
+        modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Row(
-            modifier = Modifier.weight(1.9f),
+            modifier = Modifier.weight(2.2f),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (detail.imageUrl.isBlank()) {
-                Box(
-                    modifier = Modifier
-                        .size(52.dp)
-                        .background(Color(0xFFF1F1F1), RoundedCornerShape(8.dp))
-                        .border(1.dp, Color(0xFFE7E7E7), RoundedCornerShape(8.dp))
-                )
-            } else {
-                AsyncImage(
-                    model = detail.imageUrl,
-                    contentDescription = detail.productName,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .size(52.dp)
-                        .background(Color(0xFFF1F1F1), RoundedCornerShape(8.dp))
-                        .border(1.dp, Color(0xFFE7E7E7), RoundedCornerShape(8.dp))
-                )
-            }
-            Spacer(modifier = Modifier.width(10.dp))
-            Column {
-                Text(text = detail.productName, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+            ProductThumbnail(detail = detail)
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Color: ${detail.color} | Size: ${detail.size}",
-                    fontSize = 14.sp,
-                    color = Color.Gray
+                    text = detail.productName,
+                    color = Color.Black,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = "Color ${detail.color}, Size ${detail.size}",
+                    fontSize = 12.sp,
+                    color = Color(0xFF6B6468),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }
 
         Text(
-            text = "x${detail.quantity}",
-            modifier = Modifier.weight(0.5f),
-            fontSize = 16.sp
+            text = detail.quantity.toString(),
+            modifier = Modifier.weight(0.7f),
+            color = Color.Black,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center
         )
         Text(
             text = formatAdminPrice(detail.unitPrice.toString()),
-            modifier = Modifier.weight(1.2f),
+            modifier = Modifier.weight(1.3f),
+            color = Color.Black,
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.End
         )
+    }
+}
+
+@Composable
+private fun ProductThumbnail(detail: Detail) {
+    Box(
+        modifier = Modifier
+            .size(56.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color(0xFFF3F3F3)),
+        contentAlignment = Alignment.Center
+    ) {
+        if (detail.imageUrl.isBlank()) {
+            Text(
+                text = "KicksHub",
+                color = Color(0xFF8A8588),
+                fontSize = 9.sp,
+                fontWeight = FontWeight.Bold
+            )
+        } else {
+            AsyncImage(
+                model = detail.imageUrl,
+                contentDescription = detail.productName,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.matchParentSize()
+            )
+        }
     }
 }
 
@@ -190,17 +311,46 @@ private fun UserDetailMetaRow(
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
         Text(
             text = "$label:",
-            modifier = Modifier.width(72.dp),
-            color = Color(0xFF666666),
-            fontSize = 16.sp,
+            modifier = Modifier.width(96.dp),
+            color = Color(0xFF484044),
+            fontSize = 17.sp,
             fontWeight = FontWeight.Medium
         )
         Text(
             text = value,
             modifier = Modifier.weight(1f),
-            color = Color(0xFF2E2E2E),
+            color = Color.Black,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun PriceSummaryRow(
+    label: String,
+    value: String,
+    labelWeight: FontWeight = FontWeight.Medium,
+    valueWeight: FontWeight = FontWeight.Medium,
+    valueSize: androidx.compose.ui.unit.TextUnit = 18.sp
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            color = Color(0xFF4C4448),
             fontSize = 17.sp,
-            fontWeight = FontWeight.SemiBold
+            fontWeight = labelWeight
+        )
+        Text(
+            text = value,
+            color = Color.Black,
+            fontSize = valueSize,
+            fontWeight = valueWeight,
+            textAlign = TextAlign.End
         )
     }
 }

--- a/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/ui/components/UserOrderCard.kt
+++ b/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/ui/components/UserOrderCard.kt
@@ -1,7 +1,9 @@
 package com.example.shoestoreapp.features.user.invoice.ui.components
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -10,29 +12,36 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.example.shoestoreapp.features.admin.invoice.ui.components.formatAdminDate
 import com.example.shoestoreapp.features.admin.invoice.ui.components.formatAdminPrice
+import com.example.shoestoreapp.features.invoice.model.Detail
 import com.example.shoestoreapp.features.invoice.model.Invoice
 import com.example.shoestoreapp.features.invoice.model.InvoiceStatus
-import com.example.shoestoreapp.features.invoice.ui.components.InvoiceCardContainer
-import com.example.shoestoreapp.features.invoice.ui.components.InvoiceStatusOrUnknown
 import com.example.shoestoreapp.features.invoice.ui.components.invoiceTextOrDash
 
 @Composable
 fun UserOrderCard(
     invoice: Invoice,
+    previewDetail: Detail? = null,
     isCancelling: Boolean = false,
     onCancelClick: () -> Unit = {},
     onDetailsClick: () -> Unit
@@ -40,95 +49,139 @@ fun UserOrderCard(
     val paymentMethodText = invoiceTextOrDash(invoice.paymentMethod)
     val createdAtText = formatAdminDate(invoiceTextOrDash(invoice.createdAt))
     val finalPriceText = formatAdminPrice(invoiceTextOrDash(invoice.finalPrice))
+    val title = previewDetail?.productName?.takeIf { it.isNotBlank() } ?: "Order ${invoice.orderCode}"
+    val description = previewDetail?.let { detail ->
+        listOf(
+            detail.color.takeIf { it.isNotBlank() }?.let { "Color $it" },
+            "Size ${detail.size}",
+            "x${detail.quantity}"
+        ).filterNotNull().joinToString(", ")
+    } ?: "$paymentMethodText - $createdAtText"
 
-    InvoiceCardContainer {
-        Row(
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp)
+    ) {
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = invoice.orderCode,
-                        color = Color(0xFF757575),
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    InvoiceStatusOrUnknown(status = invoice.status, unknownFontSize = 11.sp)
-                }
-
-                Spacer(modifier = Modifier.size(4.dp))
-
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Text(
-                    text = paymentMethodText,
-                    color = Color(0xFF666666),
-                    fontSize = 12.sp
+                    text = "#${invoice.orderCode}",
+                    color = Color(0xFF817B7D),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                OrderStatusPill(status = invoice.status)
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OrderPreviewImage(
+                    imageUrl = previewDetail?.imageUrl.orEmpty(),
+                    contentDescription = title
                 )
 
-                Spacer(modifier = Modifier.size(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        color = Color.Black,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = description,
+                        color = Color(0xFF3F383B),
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
+            HorizontalDivider(color = Color(0xFFF0EDEF))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "TOTAL PAYMENT",
+                        color = Color(0xFF857F82),
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        letterSpacing = 0.6.sp
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = finalPriceText,
+                        color = Color.Black,
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Black
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(10.dp))
+
+                Column(horizontalAlignment = Alignment.End) {
+                    OutlinedButton(
+                        onClick = onDetailsClick,
+                        modifier = Modifier.height(42.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        border = BorderStroke(1.4.dp, Color.Black),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = Color.White,
+                            contentColor = Color.Black
+                        ),
+                        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 0.dp)
+                    ) {
                         Text(
-                            text = createdAtText,
-                            color = Color(0xFF6B6B6B),
-                            fontSize = 12.sp
-                        )
-                        Text(
-                            text = finalPriceText,
-                            color = Color.Black,
-                            fontSize = 18.sp,
+                            text = "View details",
+                            fontSize = 12.sp,
                             fontWeight = FontWeight.ExtraBold
                         )
                     }
 
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        if (invoice.status == InvoiceStatus.PENDING) {
-                            OutlinedButton(
-                                onClick = onCancelClick,
-                                enabled = !isCancelling,
-                                modifier = Modifier.height(34.dp),
-                                shape = RoundedCornerShape(8.dp),
-                                border = BorderStroke(1.dp, Color.Black),
-                                colors = ButtonDefaults.outlinedButtonColors(
-                                    containerColor = Color.White,
-                                    contentColor = Color.Black
-                                ),
-                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp)
-                            ) {
-                                Text(
-                                    text = if (isCancelling) "Cancelling..." else "Cancel",
-                                    fontSize = 12.sp,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                            }
-                        }
-
-                        Button(
-                            onClick = onDetailsClick,
-                            modifier = Modifier.height(34.dp),
-                            shape = RoundedCornerShape(8.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = Color.Black,
-                                contentColor = Color.White
+                    if (invoice.status == InvoiceStatus.PENDING) {
+                        Spacer(modifier = Modifier.height(6.dp))
+                        OutlinedButton(
+                            onClick = onCancelClick,
+                            enabled = !isCancelling,
+                            modifier = Modifier.height(32.dp),
+                            shape = RoundedCornerShape(10.dp),
+                            border = BorderStroke(1.dp, Color(0xFFD6D1D4)),
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                containerColor = Color.White,
+                                contentColor = Color(0xFF5D5659)
                             ),
-                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp)
+                            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp)
                         ) {
                             Text(
-                                text = "View Details",
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.SemiBold
+                                text = if (isCancelling) "Cancelling..." else "Cancel",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold
                             )
                         }
                     }
@@ -136,4 +189,57 @@ fun UserOrderCard(
             }
         }
     }
+}
+
+@Composable
+private fun OrderPreviewImage(
+    imageUrl: String,
+    contentDescription: String
+) {
+    Box(
+        modifier = Modifier
+            .size(72.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color(0xFFF1F1F1)),
+        contentAlignment = Alignment.Center
+    ) {
+        if (imageUrl.isBlank()) {
+            Text(
+                text = "KicksHub",
+                color = Color(0xFF8A8588),
+                fontSize = 9.sp,
+                fontWeight = FontWeight.Bold
+            )
+        } else {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = contentDescription,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.matchParentSize()
+            )
+        }
+    }
+}
+
+@Composable
+private fun OrderStatusPill(status: InvoiceStatus?) {
+    val (label, backgroundColor, textColor) = when (status) {
+        InvoiceStatus.PENDING -> Triple("PENDING", Color(0xFFFFF2D6), Color(0xFFB07A00))
+        InvoiceStatus.PAID -> Triple("PAID", Color(0xFFEAF3FF), Color(0xFF2174E8))
+        InvoiceStatus.DELIVERING -> Triple("DELIVERING", Color(0xFFEAF3FF), Color(0xFF2174E8))
+        InvoiceStatus.DELIVERED -> Triple("COMPLETED", Color(0xFFE5F6EA), Color(0xFF11823B))
+        InvoiceStatus.CANCELLED -> Triple("CANCELLED", Color(0xFFFFE8E8), Color(0xFFC62828))
+        null -> Triple("UNKNOWN", Color(0xFFF0EEF0), Color(0xFF6A6266))
+    }
+
+    Text(
+        text = label,
+        modifier = Modifier
+            .background(backgroundColor, RoundedCornerShape(999.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        color = textColor,
+        fontSize = 10.sp,
+        fontWeight = FontWeight.ExtraBold,
+        maxLines = 1
+    )
 }

--- a/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/viewmodel/UserInvoiceViewModel.kt
+++ b/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/invoice/viewmodel/UserInvoiceViewModel.kt
@@ -30,6 +30,8 @@ data class UserInvoiceState(
     val selectedInvoice: Invoice? = null,
     // Line items of selected invoice.
     val invoiceDetails: List<Detail> = emptyList(),
+    // First line item by invoice id, used as the order list thumbnail.
+    val orderPreviewDetails: Map<String, Detail> = emptyMap(),
     // Controls details bottom-sheet loading state.
     val isDetailLoading: Boolean = false,
     // True while cancel request is in progress.
@@ -61,6 +63,7 @@ class UserInvoiceViewModel(
                         invoices = invoices,
                         orderCounts = buildOrderCounts(invoices)
                     )
+                    loadOrderPreviewDetails(invoices)
                 }
                 .onFailure { throwable ->
                     state = state.copy(
@@ -101,7 +104,18 @@ class UserInvoiceViewModel(
 
             repository.getInvoiceDetailsUser(invoiceGuid)
                 .onSuccess { detailsList ->
-                    state = state.copy(isDetailLoading = false, invoiceDetails = detailsList)
+                    val firstDetail = detailsList.firstOrNull()
+                    val previewDetails = if (firstDetail != null) {
+                        state.orderPreviewDetails + (invoice.publicId to firstDetail)
+                    } else {
+                        state.orderPreviewDetails
+                    }
+
+                    state = state.copy(
+                        isDetailLoading = false,
+                        invoiceDetails = detailsList,
+                        orderPreviewDetails = previewDetails
+                    )
                 }
                 .onFailure { throwable ->
                     state = state.copy(
@@ -222,6 +236,23 @@ class UserInvoiceViewModel(
     private fun buildOrderCounts(invoices: List<Invoice>): Map<InvoiceStatus, Int> {
         return InvoiceStatus.entries.associateWith { status ->
             invoices.count { invoice -> invoice.status == status }
+        }
+    }
+
+    private fun loadOrderPreviewDetails(invoices: List<Invoice>) {
+        invoices.forEach { invoice ->
+            val invoiceGuid = invoice.publicId.trim()
+            if (invoiceGuid.isEmpty() || state.orderPreviewDetails.containsKey(invoiceGuid)) return@forEach
+
+            viewModelScope.launch {
+                repository.getInvoiceDetailsUser(invoiceGuid)
+                    .onSuccess { detailsList ->
+                        val firstDetail = detailsList.firstOrNull() ?: return@onSuccess
+                        state = state.copy(
+                            orderPreviewDetails = state.orderPreviewDetails + (invoiceGuid to firstDetail)
+                        )
+                    }
+            }
         }
     }
 }

--- a/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/profile/ui/screens/ProfileScreen.kt
+++ b/Frontend/app/src/main/java/com/example/shoestoreapp/features/user/profile/ui/screens/ProfileScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.outlined.Event
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.ReceiptLong
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -49,6 +50,7 @@ fun UserProfileScreen(
     onChangePasswordClick: () -> Unit = {},
     onManageAddressClick: () -> Unit = {},
     onMyVouchersClick: () -> Unit = {},
+    onMyOrdersClick: () -> Unit = {},
     onLogoutClick: () -> Unit = {}
 ) {
     val profile by viewModel.profileState.collectAsState()
@@ -141,6 +143,12 @@ fun UserProfileScreen(
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 ProfileSectionLabel(text = "Account")
+
+                ProfileMenuItem(
+                    icon = Icons.Outlined.ReceiptLong,
+                    label = "My Orders",
+                    onClick = onMyOrdersClick
+                )
 
                 ProfileMenuItem(
                     icon = Icons.Outlined.ConfirmationNumber,


### PR DESCRIPTION
## Summary
- add a Profile entry for user order management
- redesign the Orders screen with compact order cards and first-item thumbnails
- rebuild the Order details bottom sheet as a cleaner invoice-style view

## Verification
- ./gradlew.bat :app:compileDebugKotlin